### PR TITLE
Fix environment variable issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## sillsdev/aws-kubectl
+
 The Docker image is based off of `ubuntu:20.04` and adds:
 
 - aws-cli version 2;
@@ -7,14 +9,14 @@ The Docker image is based off of `ubuntu:20.04` and adds:
 
 The default user is `user` whose home directory is `/home/user`.
 
-# Running `ecr-get-login.sh`
+### Running `ecr-get-login.sh`
 
 The `ecr-get-login.sh` script will generate a login token to AWS ECR and store
 it in a `kubernetes.io/dockerconfigjson` type Secret. The secret will be created
 in each of the requested namespaces (see `NAMESPACES` under
 [Environment Variables](#environment-variables)). The login token is valid for 12 hours.
 
-## Environment Variables
+### Environment Variables
 
 `ecr-get-login.sh` requires the following environment variables to be set
 before it is invoked:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ before it is invoked:
 | Variable Name         | Meaning                                                                                                                 |
 | --------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | NAMESPACES            | A space-separated list of namespaces. `ecr-get-login.sh` will create the login secret in each of the namespaces listed. |
-| SECRET_NAME           | The name of the Kubernetes secret to be created. This will be the what is listed in the `imagePullSecrets`              |
+| PULL_SECRET_NAME      | The name of the Kubernetes secret to be created. This will be the what is listed in the `imagePullSecrets`              |
 | DOCKER_EMAIL          | E-mail address to be listed in the `docker-registry` secret                                                             |
 | AWS_ACCOUNT           | The 12-digit AWS account number                                                                                         |
 | AWS_REGION            | The region, or availability zone, for the AWS_ACCOUNT                                                                   |

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@
 # build.sh will build the sillsdev/aws-kubectl as
 # an untagged image and push it to Docker Hub.  (Docker Hub
 # will assign this image the tag "latest")
-# It will then for each tag provided as a command argument, it will:
+# For each tag provided as a command argument, it will:
 #   - add the tag to the latest image that was just built
 #   - push the image to Docker Hub
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+docker build -t sillsdev/aws-kubectl -f Dockerfile .
+docker push sillsdev/aws-kubectl
+while [ $# -gt 0 ] ; do
+  docker tag sillsdev/aws-kubectl:latest sillsdev/aws-kubectl:$1
+  docker push sillsdev/aws-kubectl:$1
+  shift
+done

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,24 @@
 #! /bin/bash
 
-docker build -t sillsdev/aws-kubectl -f Dockerfile .
-docker push sillsdev/aws-kubectl
+#####################################################
+# build.sh - script to build and push the
+# sillsdev/aws-kubectl image to Docker Hub
+#
+# Usage:
+#   build.sh [ tag1, tag2, ...]
+#
+# build.sh will build the sillsdev/aws-kubectl as
+# an untagged image and push it to Docker Hub.  (Docker Hub
+# will assign this image the tag "latest")
+# It will then for each tag provided as a command argument, it will:
+#   - add the tag to the latest image that was just built
+#   - push the image to Docker Hub
+
+IMAGE=sillsdev/aws-kubectl
+docker build -t ${IMAGE} -f Dockerfile .
+docker push ${IMAGE}
 while [ $# -gt 0 ] ; do
-  docker tag sillsdev/aws-kubectl:latest sillsdev/aws-kubectl:$1
-  docker push sillsdev/aws-kubectl:$1
+  docker tag ${IMAGE}:latest ${IMAGE}:$1
+  docker push ${IMAGE}:$1
   shift
 done

--- a/scripts/ecr-get-login.sh
+++ b/scripts/ecr-get-login.sh
@@ -24,4 +24,4 @@ do
 done
 
 echo "Patching default serviceaccount"
-echo kubectl patch serviceaccount default -p "{\"imagePullSecrets\":[{\"name\":${PULL_SECRET_NAME}}]}"
+kubectl patch serviceaccount default -p "{\"imagePullSecrets\":[{\"name\": \"${PULL_SECRET_NAME}\"}]}"

--- a/scripts/ecr-get-login.sh
+++ b/scripts/ecr-get-login.sh
@@ -2,9 +2,9 @@
 set -e
 
 echo "Retrieving Docker Credentials for the AWS ECR Registry ${AWS_ACCOUNT}"
-DOCKER_REGISTRY_SERVER=${AWS_ACCOUNT}.dkr.ecr.${AWS_REGION}.amazonaws.com
+DOCKER_REGISTRY_SERVER=${AWS_ACCOUNT}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com
 DOCKER_USER=AWS
-DOCKER_PASSWORD=`aws ecr get-login-password --region ${AWS_REGION}`
+DOCKER_PASSWORD=`aws ecr get-login-password --region ${AWS_DEFAULT_REGION}`
 
 for namespace in ${NAMESPACES}
 do
@@ -24,4 +24,4 @@ do
 done
 
 echo "Patching default serviceaccount"
-echo kubectl patch serviceaccount default -p '{"imagePullSecrets":[{"name":"aws-registry"}]}'
+echo kubectl patch serviceaccount default -p "{\"imagePullSecrets\":[{\"name\":${PULL_SECRET_NAME}}]}"

--- a/scripts/ecr-get-login.sh
+++ b/scripts/ecr-get-login.sh
@@ -12,10 +12,10 @@ do
 	echo "Working in Namespace ${namespace}"
 	echo
 	echo "Removing previous secret in namespace ${namespace}"
-	kubectl --namespace=${namespace} delete --ignore-not-found secret ${SECRET_NAME}
+	kubectl --namespace=${namespace} delete --ignore-not-found secret ${PULL_SECRET_NAME}
 
 	echo "Creating new secret in namespace ${namespace}"
-	kubectl create secret docker-registry ${SECRET_NAME} \
+	kubectl create secret docker-registry ${PULL_SECRET_NAME} \
 		--docker-server=$DOCKER_REGISTRY_SERVER \
 		--docker-username=$DOCKER_USER \
 		--docker-password=$DOCKER_PASSWORD \


### PR DESCRIPTION
This PR contains the following improvements:
- README.md headers are not so bold as before
- Changed environment variable `SECRET_NAME` to `PULL_SECRET_NAME` to make it more specific
- Corrected `AWS_REGION` to `AWS_DEFAULT_REGION` as expected by the `aws-cli`
- Replaced hard-coded secret name with `${PULL_SECRET_NAME}` in `ecr-get-login.sh`
- Add `bash` script to build the docker image and push it to Docker Hub

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/aws-kubectl/2)
<!-- Reviewable:end -->
