### PR TITLE
Remove Windows' carriage returns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,15 @@ RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/s
   && mv kubectl /usr/local/bin \
   && chmod +x /usr/local/bin/kubectl
 
+# Create non-root user with a fixed UID
 ENV HOME=/home/user
-
 RUN adduser --system --group --uid 999 --home $HOME user
+
+# Add executable scripts without Windows carriage returns
+ADD scripts/*.sh /usr/local/bin/
+RUN sed -i 's/\r$//' /usr/local/bin/*.sh
+RUN chmod +x /usr/local/bin/*.sh
+
+# Change to non-root user
 USER user
 WORKDIR $HOME
-
-ADD scripts/*.sh /usr/local/bin/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 SIL LSDev
+Copyright (c) 2021-2026 SIL LSDev
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
https://gallery.ecr.aws/thecombine/aws-kubectl version 0.4.0 was built on Windows and secretly had `/r/n` line endings. This can cause the script to crash on Linux. Specifically, the first line of `scripts/ecr-get-login.sh` is
```
#!/usr/bin/env sh
```
which can result in:
```
/usr/bin/env: 'sh\r': No such file or directory
```

Version 0.4.1 is based on this branch.

https://app.devin.ai/review/sillsdev/aws-kubectl/pull/6